### PR TITLE
Use tinyverse.netlify.app for dependency badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CRAN version](http://www.r-pkg.org/badges/version/RcppArray)](https://cran.r-project.org/package=RcppArray) [![CI](https://github.com/jonclayden/RcppArray/actions/workflows/ci.yaml/badge.svg)](https://github.com/jonclayden/RcppArray/actions/workflows/ci.yaml) [![Dependencies](https://tinyverse.netlify.com/badge/RcppArray)](https://tinyverse.netlify.app)
+[![CRAN version](http://www.r-pkg.org/badges/version/RcppArray)](https://cran.r-project.org/package=RcppArray) [![CI](https://github.com/jonclayden/RcppArray/actions/workflows/ci.yaml/badge.svg)](https://github.com/jonclayden/RcppArray/actions/workflows/ci.yaml) [![Dependencies](https://tinyverse.netlify.app/badge/RcppArray)](https://tinyverse.netlify.app)
 
 
 # `Rcpp` interoperability with `std::array` (et al.)


### PR DESCRIPTION
Sadly netlify made that change requiring all URLs to be updated. I did so in a number of my repos. The change is otherwise harmless.