### PR TITLE
Update artifact action to v4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,7 @@ jobs:
     # Upload the check directory as an artefact on failure
     - name: Upload check results
       if: failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.os }}-results
         path: Rcheck


### PR DESCRIPTION
GitHub emailed that 'artifact' actions v3 would be EOL real soon. When `grep`ing among my repos I noticed this one had a v3 too so here is a quick and hopefully uncontroversial PR to update this.