### PR TITLE
Update checkout and upload-artifact actions to @v6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
     
     - name: Install and set up R
       uses: r-lib/actions/setup-r@v2
@@ -55,7 +55,7 @@ jobs:
     # Upload the check directory as an artefact on failure
     - name: Upload check results
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: ${{ matrix.os }}-results
         path: Rcheck


### PR DESCRIPTION
Another not-really-urgent PR to update two more actions to current versions.  